### PR TITLE
chore: Remove tailwindcss types as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@types/node": "^20.4.5",
         "@types/react": "^18.2.17",
         "@types/react-dom": "^18.2.7",
-        "@types/tailwindcss": "^3.1.0",
         "autoprefixer": "^10.4.14",
         "copy-webpack-plugin": "^11.0.0",
         "css-loader": "^6.8.1",
@@ -1986,16 +1985,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
-    },
-    "node_modules/@types/tailwindcss": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/tailwindcss/-/tailwindcss-3.1.0.tgz",
-      "integrity": "sha512-JxPzrm609hzvF4nmOI3StLjbBEP3WWQxDDJESqR1nh94h7gyyy3XSl0hn5RBMJ9mPudlLjtaXs5YEBtLw7CnPA==",
-      "deprecated": "This is a stub types definition. tailwindcss provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "tailwindcss": "*"
-      }
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.9",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@types/node": "^20.4.5",
     "@types/react": "^18.2.17",
     "@types/react-dom": "^18.2.7",
-    "@types/tailwindcss": "^3.1.0",
     "autoprefixer": "^10.4.14",
     "copy-webpack-plugin": "^11.0.0",
     "css-loader": "^6.8.1",


### PR DESCRIPTION
Resolve `npm` warning about the need to no longer install Tailwind CSS types separately.

```shell
npm WARN deprecated @types/tailwindcss@3.1.0: This is a stub types definition. tailwindcss provides its own type definitions, so you do not need this installed.
```